### PR TITLE
Added the functionnality to be able to reparent items

### DIFF
--- a/src/main/java/de/catma/repository/git/GitProjectHandler.java
+++ b/src/main/java/de/catma/repository/git/GitProjectHandler.java
@@ -199,22 +199,12 @@ public class GitProjectHandler {
 	public String moveTagAndUpdateAnnotations(TagsetDefinition tsdFrom, TagsetDefinition tsdTo, TagDefinition tdFrom, TagDefinition tdTo, Multimap<String, TagInstance> tagInstancesByCollectionId, String commitMsg) throws IOException {
 		try (LocalGitRepositoryManager localGitRepoManager = localGitRepositoryManager) {
 			localGitRepoManager.open(projectReference.getNamespace(), projectReference.getProjectId());
-
-			for (String collectionId : tagInstancesByCollectionId.keySet()) {
-				// TODO: code the part where we update the Instances
-				// removeTagInstances(collectionId, tagInstancesByCollectionId.get(collectionId));
-				addCollectionToStaged(collectionId);
-			}
-
 			GitTagsetHandler gitTagsetHandler = new GitTagsetHandler(
 					localGitRepoManager,
 					projectPath,
 					remoteGitServerManager.getUsername(),
 					remoteGitServerManager.getEmail()
 			);
-			System.out.println(tdFrom.getUuid());
-			System.out.println("parent to:" + tdTo.getParentUuid());
-			System.out.println("parent from:" + tdFrom.getParentUuid());
 			String projectRevision = gitTagsetHandler.moveTagDefinition(tdFrom, tdTo, commitMsg);
 
 			localGitRepoManager.push(jGitCredentialsManager);

--- a/src/main/java/de/catma/repository/git/GitProjectHandler.java
+++ b/src/main/java/de/catma/repository/git/GitProjectHandler.java
@@ -196,6 +196,34 @@ public class GitProjectHandler {
 		}
 	}
 
+	public String moveTagAndUpdateAnnotations(TagsetDefinition tsdFrom, TagsetDefinition tsdTo, TagDefinition tdFrom, TagDefinition tdTo, Multimap<String, TagInstance> tagInstancesByCollectionId, String commitMsg) throws IOException {
+		try (LocalGitRepositoryManager localGitRepoManager = localGitRepositoryManager) {
+			localGitRepoManager.open(projectReference.getNamespace(), projectReference.getProjectId());
+
+			for (String collectionId : tagInstancesByCollectionId.keySet()) {
+				// TODO: code the part where we update the Instances
+				// removeTagInstances(collectionId, tagInstancesByCollectionId.get(collectionId));
+				addCollectionToStaged(collectionId);
+			}
+
+			GitTagsetHandler gitTagsetHandler = new GitTagsetHandler(
+					localGitRepoManager,
+					projectPath,
+					remoteGitServerManager.getUsername(),
+					remoteGitServerManager.getEmail()
+			);
+			System.out.println(tdFrom.getUuid());
+			System.out.println("parent to:" + tdTo.getParentUuid());
+			System.out.println("parent from:" + tdFrom.getParentUuid());
+			String projectRevision = gitTagsetHandler.moveTagDefinition(tdFrom, tdTo, commitMsg);
+
+			localGitRepoManager.push(jGitCredentialsManager);
+
+			return projectRevision;
+		}
+	}
+
+
 	public String removeTagAndAnnotations(TagDefinition tagDefinition, Multimap<String, TagInstance> tagInstancesByCollectionId) throws IOException {
 		try (LocalGitRepositoryManager localGitRepoManager = localGitRepositoryManager) {
 			localGitRepoManager.open(projectReference.getNamespace(), projectReference.getProjectId());

--- a/src/main/java/de/catma/repository/git/GitTagsetHandler.java
+++ b/src/main/java/de/catma/repository/git/GitTagsetHandler.java
@@ -232,23 +232,6 @@ public class GitTagsetHandler {
 		String serializedGitTagDefinition =
 				new SerializationHelper<GitTagDefinition>().serialize(gitTagDefinition);
 
-		File tagsetHeaderFile = Paths.get(fromTagsetDir + HEADER_FILE_NAME).toFile();
-		String serializedTagsetHeader = FileUtils.readFileToString(tagsetHeaderFile, StandardCharsets.UTF_8);
-		GitTagsetHeader gitTagsetHeader = new SerializationHelper<GitTagsetHeader>()
-				.deserialize(
-						serializedTagsetHeader,
-						GitTagsetHeader.class
-				);
-		serializedTagsetHeader = new SerializationHelper<GitTagsetHeader>().serialize(gitTagsetHeader);
-		gitTagsetHeader.getDeletedDefinitions().add(tdFrom.getUuid());
-
-		serializedTagsetHeader =
-				new SerializationHelper<GitTagsetHeader>().serialize(gitTagsetHeader);
-
-		this.localGitRepositoryManager.add(
-				tagsetHeaderFile,
-			serializedTagsetHeader.getBytes(StandardCharsets.UTF_8));
-
 		String projectRevision = this.localGitRepositoryManager.addAndCommit(
 			Paths.get(toPath + pdj).toFile(),
 			serializedGitTagDefinition.getBytes(StandardCharsets.UTF_8),

--- a/src/main/java/de/catma/repository/git/GitTagsetHandler.java
+++ b/src/main/java/de/catma/repository/git/GitTagsetHandler.java
@@ -171,6 +171,69 @@ public class GitTagsetHandler {
 
 		return contentInfoSet;
 	}
+
+	/**
+	 * Moves a tag definition between one or multiple tagsets identified by <code>tagsetId</code>.
+	 *
+	 * @param tsdFrom {@link TagsetDefinition} source
+	 * @param tsdTo {@link TagsetDefinition} destination
+	 * @param tdFrom {@link TagDefinition} source
+	 * @param tdTo {@link TagDefinition} destination
+	 * @param commitMsg commit message
+	 * @return the new project revision hash
+	 * @throws IOException if an error occurs during the move of the tag definition
+	 */
+	public String moveTagDefinition(
+			TagDefinition tdFrom,
+			TagDefinition tdTo,
+			String commitMsg
+	) throws IOException {
+		String common =	String.format("%s/%s/", this.projectDirectory.getAbsolutePath(), GitProjectHandler.TAGSETS_DIRECTORY_NAME);
+		String fromTagsetDir = String.format("%s/%s/", common, tdFrom.getTagsetDefinitionUuid());
+		String toTagsetDir = String.format("%s/%s/", common, tdTo.getTagsetDefinitionUuid());
+
+		/* This work like it seems: all the folders having subdirectories have a folder
+		at the root of the tagset folder containing the subitems. This mean that the
+		hiearchy isn't stored as it is in the UI. */
+		String fromPath = fromTagsetDir +
+			(StringUtils.isEmpty(tdFrom.getParentUuid()) ? "" : (tdFrom.getParentUuid() + "/"))
+			+ tdFrom.getUuid();
+		String toPath = toTagsetDir +
+			(StringUtils.isEmpty(tdTo.getParentUuid()) ? "" : (tdTo.getParentUuid() + "/"))
+			+ tdTo.getUuid();
+		File from = Paths.get(fromPath).toFile();
+		File to = Paths.get(toPath).toFile();
+		if ((StringUtils.isEmpty(tdFrom.getParentUuid()) && StringUtils.isEmpty(tdTo.getParentUuid())) ||
+			(!StringUtils.isEmpty(tdFrom.getParentUuid()) && !StringUtils.isEmpty(tdTo.getParentUuid()))) {
+			/* if we move from an item in a tree somewhere to an item in a tree somewhere else, or if we
+				move a parent around in the root of the hierarchy, its fine, we just move the folder
+                                around */
+			FileUtils.moveDirectory(from, to);
+			this.localGitRepositoryManager.remove(Paths.get(fromPath + "/propertydefs.json").toFile());
+			this.localGitRepositoryManager.remove(from);
+		}
+		if (StringUtils.isEmpty(tdFrom.getParentUuid()) && !StringUtils.isEmpty(tdTo.getParentUuid())) {
+			/* if we moved from an empty parent to an object lower in the hierarchy, we need to bring the child back down */
+		}
+		if (StringUtils.isEmpty(tdTo.getParentUuid()) && !StringUtils.isEmpty(tdFrom.getParentUuid())) {
+			/* If we moved back to the root, our children are already in a directory called with our UUID at the root,
+			we need to not squish them */
+		}
+
+		GitTagDefinition gitTagDefinition = new GitTagDefinition(tdTo);
+		String serializedGitTagDefinition =
+				new SerializationHelper<GitTagDefinition>().serialize(gitTagDefinition);
+
+		String projectRevision = this.localGitRepositoryManager.addAndCommit(
+			Paths.get(to + "/propertydefs.json").toFile(),
+			serializedGitTagDefinition.getBytes(StandardCharsets.UTF_8),
+			commitMsg,
+			this.username,
+			this.email);
+		System.out.println("Deletion test commit:" + projectRevision);
+		return projectRevision;
+	}
+
 	
 	/**
 	 * Creates a tag definition within the tagset identified by <code>tagsetId</code>.
@@ -187,6 +250,9 @@ public class GitTagsetHandler {
 			String commitMsg
 	) throws IOException {
 
+		/* This work like it seems: all the folders having subdirectories have a folder
+		at the root of the tagset folder containing the subitems. This mean that the
+		hiearchy isn't stored as it is in the UI. */
 		String targetPropertyDefinitionsFileRelativePath =
 			(StringUtils.isEmpty(tagDefinition.getParentUuid()) ? "" : (tagDefinition.getParentUuid() + "/"))
 			+ tagDefinition.getUuid()

--- a/src/main/java/de/catma/tag/TagManager.java
+++ b/src/main/java/de/catma/tag/TagManager.java
@@ -220,18 +220,14 @@ public class TagManager {
 		}
 		tag.setName(updatedTag.getName());
 		tag.setColor(updatedTag.getColor());
-		System.out.println("new val: " + updatedTag.getParentUuid() + ", oldVal =" + tag.getParentUuid()  );
 		if (tag.getParentUuid() != updatedTag.getParentUuid()) {
+			tagset.reParent(tag, updatedTag.getParentUuid());
+
 			this.propertyChangeSupport.firePropertyChange(
 				TagManagerEvent.tagDefinitionMoved.name(),
 				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(tag.getTagsetDefinitionUuid()), tag),
-				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()), updatedTag));
+				new Pair<TagsetDefinition, TagDefinition>(tagset, updatedTag));
 			tag.setParentUuid(updatedTag.getParentUuid());
-			// This forces the reload of the TagDefinitions of the tagset in the resourcePanel of the annotationpanel
-			// which then sends its item to the annotation panel (which is not necessarily loaded, therefore unable
-			// to get the event above).
-			this.propertyChangeSupport.firePropertyChange(
-				TagManagerEvent.tagsetDefinitionChanged.name(), null, tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()));
 		} else {
 			this.propertyChangeSupport.firePropertyChange(
 				TagManagerEvent.tagDefinitionChanged.name(),

--- a/src/main/java/de/catma/tag/TagManager.java
+++ b/src/main/java/de/catma/tag/TagManager.java
@@ -229,11 +229,6 @@ public class TagManager {
 				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(tag.getTagsetDefinitionUuid()), tag),
 				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()), updatedTag));
 			tag.setParentUuid(updatedTag.getParentUuid());
-
-			this.propertyChangeSupport.firePropertyChange(
-				TagManagerEvent.tagDefinitionChanged.name(),
-				tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()),
-				updatedTag);
 		} else {
 			this.propertyChangeSupport.firePropertyChange(
 				TagManagerEvent.tagDefinitionChanged.name(),

--- a/src/main/java/de/catma/tag/TagManager.java
+++ b/src/main/java/de/catma/tag/TagManager.java
@@ -222,13 +222,16 @@ public class TagManager {
 		tag.setColor(updatedTag.getColor());
 		System.out.println("new val: " + updatedTag.getParentUuid() + ", oldVal =" + tag.getParentUuid()  );
 		if (tag.getParentUuid() != updatedTag.getParentUuid()) {
-			/* the update function in the json export module call "createOrModify", hence, if you change the
-			 * parent, it creates a copy, breaking your tagset, so we manually remove and re-add */
 			this.propertyChangeSupport.firePropertyChange(
 				TagManagerEvent.tagDefinitionMoved.name(),
 				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(tag.getTagsetDefinitionUuid()), tag),
 				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()), updatedTag));
 			tag.setParentUuid(updatedTag.getParentUuid());
+			// This forces the reload of the TagDefinitions of the tagset in the resourcePanel of the annotationpanel
+			// which then sends its item to the annotation panel (which is not necessarily loaded, therefore unable
+			// to get the event above).
+			this.propertyChangeSupport.firePropertyChange(
+				TagManagerEvent.tagsetDefinitionChanged.name(), null, tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()));
 		} else {
 			this.propertyChangeSupport.firePropertyChange(
 				TagManagerEvent.tagDefinitionChanged.name(),

--- a/src/main/java/de/catma/tag/TagManager.java
+++ b/src/main/java/de/catma/tag/TagManager.java
@@ -226,9 +226,14 @@ public class TagManager {
 			 * parent, it creates a copy, breaking your tagset, so we manually remove and re-add */
 			this.propertyChangeSupport.firePropertyChange(
 				TagManagerEvent.tagDefinitionMoved.name(),
-				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()), tag),
-				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(tag.getTagsetDefinitionUuid()), updatedTag));
+				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(tag.getTagsetDefinitionUuid()), tag),
+				new Pair<TagsetDefinition, TagDefinition>(tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()), updatedTag));
 			tag.setParentUuid(updatedTag.getParentUuid());
+
+			this.propertyChangeSupport.firePropertyChange(
+				TagManagerEvent.tagDefinitionChanged.name(),
+				tagLibrary.getTagsetDefinition(updatedTag.getTagsetDefinitionUuid()),
+				updatedTag);
 		} else {
 			this.propertyChangeSupport.firePropertyChange(
 				TagManagerEvent.tagDefinitionChanged.name(),

--- a/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
+++ b/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
@@ -201,6 +201,7 @@ public class AnnotationPanel extends VerticalLayout {
 	
 		            			tagsetData.addItem(parent, tagDataItem);
 		            			//TODO: sort
+						addTagSubTree(tagset, tag, (TagDataItem)tagDataItem);
 		            			
 		            			tagsetDataProvider.refreshAll();
 		            			showExpandedProperties(((TagDataItem)tagDataItem));

--- a/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
+++ b/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -82,7 +83,7 @@ public class AnnotationPanel extends VerticalLayout {
 		public void tagReferenceSelectionChanged(
 				List<TagReference> tagReferences, boolean selected);
 	}
-	
+	private static final Logger logger = Logger.getLogger(AnnotationPanel.class.getName());
 	private ComboBox<AnnotationCollection> currentEditableCollectionBox;
 	private Button btAddCollection;
 	private TreeGrid<TagsetTreeItem> tagsetGrid;
@@ -216,7 +217,46 @@ public class AnnotationPanel extends VerticalLayout {
 		project.getTagManager().addPropertyChangeListener(
 				TagManagerEvent.tagDefinitionChanged, 
 				tagChangedListener);
-		
+
+		PropertyChangeListener tagDefinitionMovedListener = new PropertyChangeListener() {
+			public void propertyChange(final PropertyChangeEvent evt) {
+				@SuppressWarnings("unchecked")
+				final Pair<TagsetDefinition, TagDefinition> newVal = (Pair<TagsetDefinition, TagDefinition>) evt.getNewValue();
+				final Pair<TagsetDefinition, TagDefinition> oldVal = (Pair<TagsetDefinition, TagDefinition>) evt.getOldValue();
+
+				System.out.println("inside the tag moved listener for the annotation panel");
+				TagsetDefinition fromTagset = newVal.getFirst();
+				TagDefinition fromTag = newVal.getSecond();
+				TagsetDefinition toTagset = newVal.getFirst();
+				TagDefinition toTag = newVal.getSecond();
+				Optional<TagsetDataItem> optionalTsdiTo = tagsetData.getRootItems().stream()
+							.map(tagsetTreeItem -> (TagsetDataItem)tagsetTreeItem)
+							.filter(tdi -> tdi.getTagset().getUuid().equals(toTagset.getUuid()))
+							.findFirst();
+				if (!optionalTsdiTo.isPresent()) {
+					logger.warning(	String.format( "Failed to find tagset with ID %1$s (to) in the AnnotationPanel TreeGrid for project \"%2$s\" with ID %3$s",
+						toTagset.getUuid(), project.getName(), project.getId()));
+					return;
+				}
+				TagsetDataItem tsdiTo = optionalTsdiTo.get();
+				TagDataItem tdiTo = new TagDataItem(toTag);
+				tdiTo.setPropertiesExpanded(true);
+
+				tagsetData.removeItem(tdiTo);
+
+				String toParent = toTag.getParentUuid();
+				TagsetTreeItem parentUpdateTo = tsdiTo;
+				if (!toParent.isEmpty()) {
+					parentUpdateTo = new TagDataItem(toTagset.getTagDefinition(toParent));
+				}
+				tagsetData.addItem(parentUpdateTo, tdiTo);
+				addTagSubTree(toTagset, toTag, tdiTo);
+				tagsetDataProvider.refreshAll();
+				showExpandedProperties(tdiTo);
+			}
+		};
+		project.getTagManager().addPropertyChangeListener(TagManagerEvent.tagDefinitionMoved, tagDefinitionMovedListener);
+
 		propertyDefinitionChangedListener = new PropertyChangeListener() {
 			
 			@SuppressWarnings("unchecked")
@@ -1214,17 +1254,20 @@ public class AnnotationPanel extends VerticalLayout {
 	}
 	
 	public void setTagsets(Collection<TagsetDefinition> tagsets) {
-		tagsets
-		.stream()
-		.filter(tagset -> !this.tagsets.contains(tagset))
-		.forEach(tagset -> addTagset(tagset));
-		
-		this.tagsets.stream()
-		.filter(tagset -> !tagsets.contains(tagset))
-		.collect(Collectors.toList())
-		.stream()
-		.forEach(tagset -> removeTagset(tagset));
+		this.tagsets.clear();
+		this.tagsets.addAll(tagsets);
+		tagsetData.clear();
+		for (TagsetDefinition tagset : tagsets) {
+			TagsetDataItem tagsetItem = new TagsetDataItem(tagset);
+			tagsetData.addItem(null, tagsetItem);
+			addTags(tagsetItem, tagset);
+		}
+		tagsetDataProvider.refreshAll();
+		for (TagsetDefinition tagset : this.tagsets) {
+			expandTagsetDefinition(tagset);
+		}
 	}
+
 
 	public void addTagset(TagsetDefinition tagset) {
 		tagsets.add(tagset);

--- a/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
+++ b/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
@@ -240,19 +240,18 @@ public class AnnotationPanel extends VerticalLayout {
 				}
 				TagsetDataItem tsdiTo = optionalTsdiTo.get();
 				TagDataItem tdiTo = new TagDataItem(toTag);
-				tdiTo.setPropertiesExpanded(true);
-
-				tagsetData.removeItem(tdiTo);
-
+				TagDataItem tdiFrom = new TagDataItem(fromTag);
 				String toParent = toTag.getParentUuid();
-				TagsetTreeItem parentUpdateTo = tsdiTo;
+				TagsetTreeItem parentUpdateTo = null;
 				if (!toParent.isEmpty()) {
 					parentUpdateTo = new TagDataItem(toTagset.getTagDefinition(toParent));
 				}
-				tagsetData.addItem(parentUpdateTo, tdiTo);
-				addTagSubTree(toTagset, toTag, tdiTo);
-				tagsetDataProvider.refreshAll();
+				System.out.println(String.format("Received info about a move from parent %1$s to %2$s with ID %3$s...",
+						fromTag.getParentUuid(), toTag.getParentUuid(), toTag.getName()));
+				tagsetData.setParent(tdiFrom, parentUpdateTo);
+				tdiTo.setPropertiesExpanded(true);
 				showExpandedProperties(tdiTo);
+				tagsetDataProvider.refreshAll();
 			}
 		};
 		project.getTagManager().addPropertyChangeListener(TagManagerEvent.tagDefinitionMoved, tagDefinitionMovedListener);

--- a/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
+++ b/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
@@ -656,7 +656,7 @@ public class AnnotationPanel extends VerticalLayout {
 						@Override
 						public void execute() {
 							
-							EditTagDialog editTagDialog = new EditTagDialog(new TagDefinition(targetTag), 
+							EditTagDialog editTagDialog = new EditTagDialog(tagsets, project.getTagManager().getTagLibrary(), new TagDefinition(targetTag),
 									new SaveCancelListener<TagDefinition>() {
 										public void savePressed(TagDefinition result) {
 											project.getTagManager().updateTagDefinition(targetTag, result);

--- a/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
+++ b/src/main/java/de/catma/ui/module/annotate/annotationpanel/AnnotationPanel.java
@@ -878,20 +878,11 @@ public class AnnotationPanel extends VerticalLayout {
 						public void execute() {
 
 							AddSubtagDialog addTagDialog =
-								new AddSubtagDialog(new SaveCancelListener<TagDefinition>() {
-									public void savePressed(TagDefinition result) {
-										for (TagDefinition parent : parentTags) {
-											
-											TagsetDefinition tagset = 
-												project.getTagManager().getTagLibrary().getTagsetDefinition(parent);
-											
-											TagDefinition tag = new TagDefinition(result);
-											tag.setUuid(idGenerator.generate());
-											tag.setParentUuid(parent.getUuid());
-											tag.setTagsetDefinitionUuid(tagset.getUuid());
-											
+								new AddSubtagDialog(new SaveCancelListener<Collection<TagDefinition>>() {
+									public void savePressed(Collection<TagDefinition> result) {
+										for (TagDefinition item : result) {
 											project.getTagManager().addTagDefinition(
-													tagset, tag);
+												project.getTagManager().getTagLibrary().getTagsetDefinition(item.getTagsetDefinitionUuid()), item);
 										}
 									};
 								});

--- a/src/main/java/de/catma/ui/module/annotate/resourcepanel/AnnotateResourcePanel.java
+++ b/src/main/java/de/catma/ui/module/annotate/resourcepanel/AnnotateResourcePanel.java
@@ -59,6 +59,7 @@ public class AnnotateResourcePanel extends VerticalLayout {
 	private ActionGridComponent<TreeGrid<DocumentTreeItem>> documentActionGridComponent;
 	private ErrorHandler errorHandler;
 	private PropertyChangeListener tagsetChangeListener;
+	private PropertyChangeListener tagMovedListener;
 	private ListDataProvider<TagsetDefinition> tagsetData;
 	private ActionGridComponent<Grid<TagsetDefinition>> tagsetActionGridComponent;
 	private EventBus eventBus;
@@ -112,8 +113,14 @@ public class AnnotateResourcePanel extends VerticalLayout {
 				handleTagsetChange(evt);
 			}
 		};
-
+		tagMovedListener = new PropertyChangeListener() {
+			@Override
+			public void propertyChange(PropertyChangeEvent evt) {
+				tagsetData.refreshAll();
+			}
+		};
 		project.getTagManager().addPropertyChangeListener(TagManagerEvent.tagsetDefinitionChanged, tagsetChangeListener);
+		project.getTagManager().addPropertyChangeListener(TagManagerEvent.tagDefinitionMoved, tagMovedListener);
 	}
 
 	private void handleTagsetChange(PropertyChangeEvent evt) {

--- a/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
@@ -266,6 +266,7 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		List<List<TagDefinition>> rootTags = availableParents.stream().map(tagset -> tagset.getRootTagDefinitions()).collect(Collectors.toList());
 		List<TagDefinition> listOfIndentedTags = new ArrayList<TagDefinition>();
 		for (TagsetDefinition subTree : availableParents) {
+			/* TODO: We need to prevent the user from unrooting the tree/branch, eg: setting an item parents as one of its children. */
 			listOfIndentedTags.addAll(unrollTree(subTree, subTree.getRootTagDefinitions(), String.valueOf('\\')));
 		}
 		if (update) {

--- a/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
@@ -1,7 +1,7 @@
 package de.catma.ui.module.tags;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +25,7 @@ import com.vaadin.ui.ComponentContainer;
 import com.vaadin.ui.Grid;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.ListSelect;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.Notification.Type;
 import com.vaadin.ui.TextArea;
@@ -56,6 +57,7 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 	protected ListDataProvider<PropertyDefinition> propertyDefDataProvider;
 	protected ColorPicker colorPicker;
 	protected TextField tfName;
+	protected ListSelect<TagDefinition> lbParent;
 
 	protected AbstractAddEditTagDialog(
 			String dialogCaption, SaveCancelListener<T> saveCancelListener) {
@@ -180,7 +182,6 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		colorPicker.setModal(true);
 		
 		tagPanel.addComponent(colorPicker);
-		
 		propertyDefNamePanel = new HorizontalLayout();
 		propertyDefNamePanel.setSpacing(true);
 		propertyDefNamePanel.setMargin(new MarginInfo(true, true, false, true));
@@ -231,6 +232,30 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		possibleValuesArea.setSizeFull();
 		
 		propertyDefPanel.addComponent(possibleValuesArea);
+	}
+
+	protected void initComponents(Collection<TagsetDefinition> availableTagsets,
+			Optional<TagsetDefinition> preSelectedTagset, boolean allowPropertyDefEditing) {
+
+		cbTagsets = new ComboBox<TagsetDefinition>("Tagset", availableTagsets);
+		cbTagsets.setItemCaptionGenerator(tagset -> tagset.getName());
+		cbTagsets.setWidth("100%");
+		cbTagsets.setDescription("The tagset that will be the container of the new tag");
+		cbTagsets.setEmptySelectionAllowed(false);
+		preSelectedTagset.ifPresent(tagset -> cbTagsets.setValue(tagset));
+		this.initComponents(allowPropertyDefEditing);
+	}
+
+	protected void initComponents(Collection<TagDefinition> availableParents,
+			Collection<TagDefinition> preSelectedParents, boolean allowPropertyDefEditing) {
+		lbParent = new ListSelect<TagDefinition>("Parent", availableParents);
+		lbParent.setItemCaptionGenerator(tag -> tag.getName());
+		lbParent.setWidth("100%");
+		lbParent.setDescription("The parent(s) of the new tag");
+		lbParent.setRows(5);
+		// lbParent.setEmptySelectionAllowed(false);
+		preSelectedParents.forEach(tag -> lbParent.select(tag));
+		this.initComponents(allowPropertyDefEditing);
 	}
 	
 	protected void setPropertyDefinitionsVisible() {

--- a/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
@@ -36,6 +36,8 @@ import com.vaadin.ui.renderers.ButtonRenderer;
 import com.vaadin.ui.renderers.ClickableRenderer.RendererClickEvent;
 
 import de.catma.tag.PropertyDefinition;
+import de.catma.tag.TagDefinition;
+import de.catma.tag.TagLibrary;
 import de.catma.tag.TagsetDefinition;
 import de.catma.ui.FocusHandler;
 import de.catma.ui.dialog.AbstractOkCancelDialog;
@@ -257,9 +259,8 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		return(listOfIndentedTags);
 
 	}
-
-	protected void initComponents(Collection<TagsetDefinition> availableParents,
-			Collection<TagDefinition> preSelectedParents, boolean allowPropertyDefEditing) {
+	protected void populateParentBox(Collection<TagsetDefinition> availableParents,
+			Collection<TagDefinition> preSelectedParents) {
 		List<List<TagDefinition>> rootTags = availableParents.stream().map(tagset -> tagset.getRootTagDefinitions()).collect(Collectors.toList());
 		List<TagDefinition> listOfIndentedTags = new ArrayList<TagDefinition>();
 		for (TagsetDefinition subTree : availableParents) {
@@ -272,6 +273,32 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		lbParent.setRows(5);
 		// lbParent.setEmptySelectionAllowed(false);
 		preSelectedParents.forEach(tag -> lbParent.select(tag));
+	}
+
+	/*
+	 * This only get called on the edit tag dialog, which has both select tagset and
+         * select parent options. There must be one selected item, which is the
+	 * one we're editing.
+         */
+	protected void initComponents(Collection<TagsetDefinition> availableTagsets,
+			TagLibrary lib,
+			TagDefinition editedTag,
+			boolean allowPropertyDefEditing) {
+		Collection<TagDefinition> parent = new ArrayList<TagDefinition>();
+		if(lib.getTagDefinition(editedTag.getParentUuid()) != null) {
+			parent.add(lib.getTagDefinition(editedTag.getParentUuid()));
+		}
+		populateParentBox(availableTagsets, parent);
+		Optional<TagsetDefinition> otsd = Optional.of(lib.getTagsetDefinition(editedTag.getTagsetDefinitionUuid()));
+		initComponents(availableTagsets, otsd, allowPropertyDefEditing);
+		cbTagsets.addValueChangeListener(event -> {
+		});
+	}
+
+	protected void initComponents(Collection<TagsetDefinition> availableParents,
+			Collection<TagDefinition> preSelectedParents, boolean allowPropertyDefEditing) {
+		populateParentBox(availableParents, preSelectedParents);
+
 		this.initComponents(allowPropertyDefEditing);
 	}
 	

--- a/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
@@ -246,9 +246,10 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		this.initComponents(allowPropertyDefEditing);
 	}
 
-	protected void initComponents(Collection<TagDefinition> availableParents,
+	protected void initComponents(Collection<TagsetDefinition> availableParents,
 			Collection<TagDefinition> preSelectedParents, boolean allowPropertyDefEditing) {
-		lbParent = new ListSelect<TagDefinition>("Parent", availableParents);
+		List<TagDefinition> rootTags = availableParents.stream().map(tagset -> tagset.getRootTagDefinitions().get(0)).collect(Collectors.toList());
+		lbParent = new ListSelect<TagDefinition>("Parent", rootTags);
 		lbParent.setItemCaptionGenerator(tag -> tag.getName());
 		lbParent.setWidth("100%");
 		lbParent.setDescription("The parent(s) of the new tag");
@@ -284,6 +285,9 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 
 	@Override
 	protected void addContent(ComponentContainer content) {
+		if (isWithParentSelection()) {
+			content.addComponent(lbParent);
+		}
 		if (isWithTagsetSelection()) {
 			content.addComponent(cbTagsets);
 		}

--- a/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
@@ -313,6 +313,7 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		}
 		Optional<TagsetDefinition> otsd = Optional.of(lib.getTagsetDefinition(editedTag.getTagsetDefinitionUuid()));
 		initComponents(availableTagsets, otsd, allowPropertyDefEditing);
+		cbTagsets.setEnabled(false);
 		cbTagsets.addValueChangeListener(event -> {
 			if (cbTagsets.getSelectedItem().isPresent()) {
 				ArrayList<TagsetDefinition> theList = new ArrayList<TagsetDefinition>();

--- a/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.github.appreciated.material.MaterialTheme;
@@ -271,12 +272,21 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 			lbParent.setDataProvider(DataProvider.ofCollection(listOfIndentedTags));
 		} else {
 			lbParent = new ListSelect<TagDefinition>("Parent", listOfIndentedTags);
+			if (isWithParentSelection() && isWithTagsetSelection()) {
+				lbParent.addSelectionListener(event -> {
+					if (lbParent.getValue().stream().count()>1) {
+						Notification.show("Info", "You can only select one parent when editing a tag. Deselecting all but the first item.", Type.TRAY_NOTIFICATION);
+						TagDefinition item = lbParent.getValue().stream().findFirst().get();
+						lbParent.deselectAll();
+						lbParent.setValue(Set.of(item));
+					}
+				});
+			}
 			lbParent.setItemCaptionGenerator(tag -> tag.getName());
 			lbParent.setWidth("100%");
 			lbParent.setDescription("The parent(s) of the new tag");
 			lbParent.setRows(5);
 		}
-		// lbParent.setEmptySelectionAllowed(false);
 		preSelectedParents.forEach(tag -> lbParent.select(tag));
 	}
 

--- a/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AbstractAddEditTagDialog.java
@@ -246,10 +246,26 @@ public abstract class AbstractAddEditTagDialog<T> extends AbstractOkCancelDialog
 		this.initComponents(allowPropertyDefEditing);
 	}
 
+	protected List<TagDefinition> unrollTree(TagsetDefinition tsd, List<TagDefinition> tags, String prefix) {
+		List<TagDefinition> listOfIndentedTags = new ArrayList<TagDefinition>();
+		for (TagDefinition subTree : tags) {
+			TagDefinition item = new TagDefinition(subTree);
+			item.setName(prefix.concat(subTree.getName()));
+			listOfIndentedTags.add(item);
+			listOfIndentedTags.addAll(unrollTree(tsd, tsd.getDirectChildren(subTree), prefix.concat("-")));
+		}
+		return(listOfIndentedTags);
+
+	}
+
 	protected void initComponents(Collection<TagsetDefinition> availableParents,
 			Collection<TagDefinition> preSelectedParents, boolean allowPropertyDefEditing) {
-		List<TagDefinition> rootTags = availableParents.stream().map(tagset -> tagset.getRootTagDefinitions().get(0)).collect(Collectors.toList());
-		lbParent = new ListSelect<TagDefinition>("Parent", rootTags);
+		List<List<TagDefinition>> rootTags = availableParents.stream().map(tagset -> tagset.getRootTagDefinitions()).collect(Collectors.toList());
+		List<TagDefinition> listOfIndentedTags = new ArrayList<TagDefinition>();
+		for (TagsetDefinition subTree : availableParents) {
+			listOfIndentedTags.addAll(unrollTree(subTree, subTree.getRootTagDefinitions(), String.valueOf('\\')));
+		}
+		lbParent = new ListSelect<TagDefinition>("Parent", listOfIndentedTags);
 		lbParent.setItemCaptionGenerator(tag -> tag.getName());
 		lbParent.setWidth("100%");
 		lbParent.setDescription("The parent(s) of the new tag");

--- a/src/main/java/de/catma/ui/module/tags/AddParenttagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AddParenttagDialog.java
@@ -25,7 +25,12 @@ public class AddParenttagDialog extends AbstractAddEditTagDialog<Pair<TagsetDefi
 	protected boolean isWithTagsetSelection() {
 		return true;
 	}
-	
+
+	@Override
+	protected boolean isWithParentSelection() {
+		return false;
+	}
+
 	@Override
 	protected String getOkCaption() {
 		return "Add Tag";

--- a/src/main/java/de/catma/ui/module/tags/AddSubtagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AddSubtagDialog.java
@@ -21,6 +21,10 @@ public class AddSubtagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 	}
 
 	@Override
+	protected boolean isWithParentSelection() {
+		return true;
+	}
+	@Override
 	protected TagDefinition getResult() {
 		
 		TagDefinition tag = 

--- a/src/main/java/de/catma/ui/module/tags/AddSubtagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AddSubtagDialog.java
@@ -1,18 +1,36 @@
 package de.catma.ui.module.tags;
 
+import java.util.Collection;
 import java.util.Collections;
 
 import de.catma.tag.PropertyDefinition;
 import de.catma.tag.TagDefinition;
+import de.catma.tag.TagsetDefinition;
 import de.catma.tag.Version;
 import de.catma.ui.dialog.SaveCancelListener;
 
 public class AddSubtagDialog extends AbstractAddEditTagDialog<TagDefinition> {
-	
-	public AddSubtagDialog(SaveCancelListener<TagDefinition> saveCancelListener) {
+
+	/* So I don't have to change all the call to this function while testing, I'm doing two functions w/ different signatures */
+	public AddSubtagDialog(
+			SaveCancelListener<TagDefinition> saveCancelListener) {
 		super("Add Subtag", saveCancelListener);
 		initComponents(false);
 		initActions();
+	}
+
+	public AddSubtagDialog(
+			Collection<TagsetDefinition> availableTags,
+			Collection<TagDefinition> preSelectedTags,
+			SaveCancelListener<TagDefinition> saveCancelListener) {
+		super("Add Subtag", saveCancelListener);
+		initComponents(availableTags, preSelectedTags, false);
+		initActions();
+		initData();
+	}
+
+	private void initData() {
+		//tfParent.setValue(isWithTagsetSelection()?cbTagsets.getValue().getUuid().toString():"");
 	}
 
 	@Override

--- a/src/main/java/de/catma/ui/module/tags/AddSubtagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/AddSubtagDialog.java
@@ -1,5 +1,7 @@
 package de.catma.ui.module.tags;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -9,11 +11,11 @@ import de.catma.tag.TagsetDefinition;
 import de.catma.tag.Version;
 import de.catma.ui.dialog.SaveCancelListener;
 
-public class AddSubtagDialog extends AbstractAddEditTagDialog<TagDefinition> {
+public class AddSubtagDialog extends AbstractAddEditTagDialog<Collection<TagDefinition>> {
 
 	/* So I don't have to change all the call to this function while testing, I'm doing two functions w/ different signatures */
 	public AddSubtagDialog(
-			SaveCancelListener<TagDefinition> saveCancelListener) {
+			SaveCancelListener<Collection<TagDefinition>> saveCancelListener) {
 		super("Add Subtag", saveCancelListener);
 		initComponents(false);
 		initActions();
@@ -22,7 +24,7 @@ public class AddSubtagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 	public AddSubtagDialog(
 			Collection<TagsetDefinition> availableTags,
 			Collection<TagDefinition> preSelectedTags,
-			SaveCancelListener<TagDefinition> saveCancelListener) {
+			SaveCancelListener<Collection<TagDefinition>> saveCancelListener) {
 		super("Add Subtag", saveCancelListener);
 		initComponents(availableTags, preSelectedTags, false);
 		initActions();
@@ -43,27 +45,32 @@ public class AddSubtagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 		return true;
 	}
 	@Override
-	protected TagDefinition getResult() {
+	protected Collection<TagDefinition> getResult() {
+		Collection<TagDefinition> parentTags = lbParent.getValue();
+		System.out.println(lbParent.getSelectedItems().stream().count());
+		System.out.println(parentTags.stream().count());
+		ArrayList<TagDefinition> allTags = new ArrayList<TagDefinition>();
+		for (TagDefinition parent : parentTags) {
+			System.out.println(parent.getName());
+			TagDefinition tag = 
+				new TagDefinition(
+					idGenerator.generate(), 
+					tfName.getValue(),
+					parent.getUuid(), 
+					parent.getTagsetDefinitionUuid());
 		
-		TagDefinition tag = 
-			new TagDefinition(
-				idGenerator.generate(), 
-				tfName.getValue(),
-				null, 
-				isWithTagsetSelection()?cbTagsets.getValue().getUuid():null);
-		
-		tag.addSystemPropertyDefinition(
-			new PropertyDefinition(
-				idGenerator.generate(PropertyDefinition.SystemPropertyName.catma_displaycolor.name()), 
-				PropertyDefinition.SystemPropertyName.catma_displaycolor.name(), 
-				Collections.singletonList(String.valueOf(colorPicker.getValue().getRGB()))));
+			tag.addSystemPropertyDefinition(
+				new PropertyDefinition(
+					idGenerator.generate(PropertyDefinition.SystemPropertyName.catma_displaycolor.name()), 
+					PropertyDefinition.SystemPropertyName.catma_displaycolor.name(), 
+					Collections.singletonList(String.valueOf(colorPicker.getValue().getRGB()))));
 
-		for (PropertyDefinition propertyDefinition : propertyDefDataProvider.getItems()) {
-			tag.addUserDefinedPropertyDefinition(propertyDefinition);
-		}		
-		
-		
-		return tag;
+			for (PropertyDefinition propertyDefinition : propertyDefDataProvider.getItems()) {
+				tag.addUserDefinedPropertyDefinition(propertyDefinition);
+			}
+			allTags.add(tag);
+		}
+		return(allTags);
 	}
 
 }

--- a/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
@@ -55,7 +55,7 @@ public class EditTagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 	@Override
 	protected TagDefinition getResult() {
 		Optional<TagDefinition> item = lbParent.getValue().stream().findFirst();
-		tagDefinition.setParentUuid(item.isPresent()?item.get().getUuid():null);
+		tagDefinition.setParentUuid(item.isPresent()?item.get().getUuid():"");
 		tagDefinition.setName(tfName.getValue());
 		tagDefinition.setColor(String.valueOf(colorPicker.getValue().getRGB()));
 		

--- a/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
@@ -3,6 +3,7 @@ package de.catma.ui.module.tags;
 import com.vaadin.shared.ui.colorpicker.Color;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import de.catma.tag.TagLibrary;
 import de.catma.tag.TagsetDefinition;
@@ -53,6 +54,8 @@ public class EditTagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 
 	@Override
 	protected TagDefinition getResult() {
+		Optional<TagDefinition> item = lbParent.getValue().stream().findFirst();
+		tagDefinition.setParentUuid(item.isPresent()?item.get().getUuid():null);
 		tagDefinition.setName(tfName.getValue());
 		tagDefinition.setColor(String.valueOf(colorPicker.getValue().getRGB()));
 		

--- a/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
@@ -2,6 +2,10 @@ package de.catma.ui.module.tags;
 
 import com.vaadin.shared.ui.colorpicker.Color;
 
+import java.util.Collection;
+
+import de.catma.tag.TagLibrary;
+import de.catma.tag.TagsetDefinition;
 import de.catma.tag.PropertyDefinition;
 import de.catma.tag.TagDefinition;
 import de.catma.ui.dialog.SaveCancelListener;
@@ -10,10 +14,10 @@ public class EditTagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 	
 	private TagDefinition tagDefinition;
 
-	public EditTagDialog(TagDefinition tagDefinition, SaveCancelListener<TagDefinition> saveCancelListener) {
+	public EditTagDialog(Collection<TagsetDefinition> scope, TagLibrary tagLibrary, TagDefinition tagDefinition, SaveCancelListener<TagDefinition> saveCancelListener) {
 		super("Edit Tag", saveCancelListener);
 		this.tagDefinition = tagDefinition;
-		initComponents(true);
+		initComponents(scope, tagLibrary, tagDefinition, true);
 		initActions();
 		setPropertyDefinitionsVisible();
 		initData(tagDefinition);

--- a/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
@@ -43,6 +43,11 @@ public class EditTagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 	}
 
 	@Override
+	protected boolean isWithParentSelection() {
+		return true;
+	}
+
+	@Override
 	protected TagDefinition getResult() {
 		tagDefinition.setName(tfName.getValue());
 		tagDefinition.setColor(String.valueOf(colorPicker.getValue().getRGB()));

--- a/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
+++ b/src/main/java/de/catma/ui/module/tags/EditTagDialog.java
@@ -39,7 +39,7 @@ public class EditTagDialog extends AbstractAddEditTagDialog<TagDefinition> {
 	
 	@Override
 	protected boolean isWithTagsetSelection() {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/src/main/java/de/catma/ui/module/tags/TagSelectionPanel.java
+++ b/src/main/java/de/catma/ui/module/tags/TagSelectionPanel.java
@@ -253,20 +253,11 @@ public class TagSelectionPanel extends VerticalLayout {
 						public void execute() {
 				
 							AddSubtagDialog addTagDialog =
-								new AddSubtagDialog(new SaveCancelListener<TagDefinition>() {
-									public void savePressed(TagDefinition result) {
-										for (TagDefinition parent : parentTags) {
-											
-											TagsetDefinition tagset = 
-												project.getTagManager().getTagLibrary().getTagsetDefinition(parent);
-											
-											TagDefinition tag = new TagDefinition(result);
-											tag.setUuid(idGenerator.generate());
-											tag.setParentUuid(parent.getUuid());
-											tag.setTagsetDefinitionUuid(tagset.getUuid());
-											
+								new AddSubtagDialog(new SaveCancelListener<Collection<TagDefinition>>() {
+									public void savePressed(Collection<TagDefinition> result) {
+										for (TagDefinition item : result) {
 											project.getTagManager().addTagDefinition(
-													tagset, tag);
+												project.getTagManager().getTagLibrary().getTagsetDefinition(item.getTagsetDefinitionUuid()), item);
 										}
 									};
 								});

--- a/src/main/java/de/catma/ui/module/tags/TagsView.java
+++ b/src/main/java/de/catma/ui/module/tags/TagsView.java
@@ -993,20 +993,12 @@ public class TagsView extends HugeCard {
 							new AddSubtagDialog(
 								tagsets,
 								parentTags,
-								new SaveCancelListener<TagDefinition>() {
-								public void savePressed(TagDefinition result) {
-									for (TagDefinition parent : parentTags) {
-										
-										TagsetDefinition tagset = 
-											project.getTagManager().getTagLibrary().getTagsetDefinition(parent);
-										
-										TagDefinition tag = new TagDefinition(result);
-										tag.setUuid(idGenerator.generate());
-										tag.setParentUuid(parent.getUuid());
-										tag.setTagsetDefinitionUuid(tagset.getUuid());
-										
+								new SaveCancelListener<Collection<TagDefinition>>() {
+								public void savePressed(Collection<TagDefinition> result) {
+									System.out.println(result.stream().count());	
+									for (TagDefinition item : result) {
 										project.getTagManager().addTagDefinition(
-												tagset, tag);
+											project.getTagManager().getTagLibrary().getTagsetDefinition(item.getTagsetDefinitionUuid()), item);
 									}
 								};
 							});

--- a/src/main/java/de/catma/ui/module/tags/TagsView.java
+++ b/src/main/java/de/catma/ui/module/tags/TagsView.java
@@ -705,7 +705,10 @@ public class TagsView extends HugeCard {
 						@Override
 						public void execute() {
 							EditTagDialog editTagDialog = 
-								new EditTagDialog(new TagDefinition(targetTag), 
+								new EditTagDialog(
+									tagsets,
+									project.getTagManager().getTagLibrary(),
+									new TagDefinition(targetTag),
 									new SaveCancelListener<TagDefinition>() {
 								public void savePressed(TagDefinition result) {
 									project.getTagManager().updateTagDefinition(targetTag, result);

--- a/src/main/java/de/catma/ui/module/tags/TagsView.java
+++ b/src/main/java/de/catma/ui/module/tags/TagsView.java
@@ -989,11 +989,9 @@ public class TagsView extends HugeCard {
 				new Action() {
 					@Override
 					public void execute() {
-						Collection<TagsetDefinition> target = new ArrayList<TagsetDefinition>();
-						project.getTagManager().getTagLibrary().forEach(target::add);
 						AddSubtagDialog addTagDialog =
 							new AddSubtagDialog(
-								target,
+								tagsets,
 								parentTags,
 								new SaveCancelListener<TagDefinition>() {
 								public void savePressed(TagDefinition result) {

--- a/src/main/java/de/catma/ui/module/tags/TagsView.java
+++ b/src/main/java/de/catma/ui/module/tags/TagsView.java
@@ -972,7 +972,6 @@ public class TagsView extends HugeCard {
 		.filter(tagsetTreeItem -> tagsetTreeItem instanceof TagDataItem)
 		.map(tagsetTreeItem -> ((TagDataItem)tagsetTreeItem).getTag())
 		.collect(Collectors.toList());
-
 		
 		if (!parentTags.isEmpty()) {
 			
@@ -990,8 +989,13 @@ public class TagsView extends HugeCard {
 				new Action() {
 					@Override
 					public void execute() {
+						Collection<TagsetDefinition> target = new ArrayList<TagsetDefinition>();
+						project.getTagManager().getTagLibrary().forEach(target::add);
 						AddSubtagDialog addTagDialog =
-							new AddSubtagDialog(new SaveCancelListener<TagDefinition>() {
+							new AddSubtagDialog(
+								target,
+								parentTags,
+								new SaveCancelListener<TagDefinition>() {
 								public void savePressed(TagDefinition result) {
 									for (TagDefinition parent : parentTags) {
 										

--- a/src/main/java/de/catma/ui/module/tags/TagsView.java
+++ b/src/main/java/de/catma/ui/module/tags/TagsView.java
@@ -206,8 +206,8 @@ public class TagsView extends HugeCard {
 				final Pair<TagsetDefinition, TagDefinition> oldVal = (Pair<TagsetDefinition, TagDefinition>) evt.getOldValue();
 
 				System.out.println("inside the tag moved listener for the TagsView");
-				TagsetDefinition fromTagset = newVal.getFirst();
-				TagDefinition fromTag = newVal.getSecond();
+				TagsetDefinition fromTagset = oldVal.getFirst();
+				TagDefinition fromTag = oldVal.getSecond();
 				TagsetDefinition toTagset = newVal.getFirst();
 				TagDefinition toTag = newVal.getSecond();
 				Optional<TagsetDataItem> optionalTsdiTo = tagsetData.getRootItems().stream()
@@ -221,17 +221,19 @@ public class TagsView extends HugeCard {
 				}
 				TagsetDataItem tsdiTo = optionalTsdiTo.get();
 				TagDataItem tdiTo = new TagDataItem(toTag, tsdiTo.isEditable());
-				tdiTo.setPropertiesExpanded(true);
-				tagsetData.removeItem(tdiTo);
+				TagDataItem tdiFrom = new TagDataItem(fromTag, tsdiTo.isEditable());
 				String toParent = toTag.getParentUuid();
-				TagsetTreeItem parentUpdateTo = tsdiTo;
+				TagsetTreeItem parentUpdateTo = null;
 				if (!toParent.isEmpty()) {
 					parentUpdateTo = new TagDataItem(toTagset.getTagDefinition(toParent));
 				}
-				tagsetData.addItem(parentUpdateTo, tdiTo);
-				addTagSubTree(toTagset, toTag, tdiTo);
-				tagsetDataProvider.refreshAll();
+				System.out.println(String.format("Received info about a move from parent %1$s to %2$s with ID %3$s...",
+						fromTag.getParentUuid(), toTag.getParentUuid(), toTag.getName()));
+
+				tagsetData.setParent(tdiFrom, parentUpdateTo);
+				tdiTo.setPropertiesExpanded(true);
 				showExpandedProperties(tdiTo);
+				tagsetDataProvider.refreshAll();
 			}
 		};
 


### PR DESCRIPTION
Hi,

I've did the necessary changes to get the ability to reParent items in the hierarchy.
This is mostly UI work, as the git backend changes were minor. Quite some care was put into making sure that if you move a tag in the tag panel, it stayed coherent in the annotation panel. A ton of testing was made, making item roots, adding them subitems, etc.

It wasn't necessary to reparent each TagInstance and TagReference, as the tags are referred in the shape "TAGSET/TAG" in the annotation file. 

Same thing goes for the deletion of tags. That would be important if moved tags in between tagsets, but it isn't necessary as the system don't freak out seeing items out of place, as long as they aren't missing. I was able to move tagsets around => sync => open on another user multiple times without issues.

This is a ton of code, so there might be new bugs introduced, but I tested quite a lot. I kept some part of a time budget to fix upcoming bugs. 